### PR TITLE
Correct Java section in programming_languages.rst

### DIFF
--- a/programming_languages.rst
+++ b/programming_languages.rst
@@ -609,14 +609,15 @@ Java
 ----
 
 ``char`` is a character able to store Unicode :ref:`BMP <bmp>` only characters
-(U+0000—U+FFFF), whereas ``Character`` is a character able to store any Unicode
-character (U+0000—U+10FFFF). ``Character`` methods:
+(U+0000—U+FFFF), whereas ``Character`` is a wrapper  of the ``char`` with static helper functions.
+``Character`` methods:
 
  * ``.getType(ch)``: get the :ref:`category <unicode categories>` of a
    character
  * ``.isWhitespace(ch)``: test if a character is a whitespace
    according to Java
  * ``.toUpperCase(ch)``: convert to uppercase
+ * ``.codePointAt(CharSequence, int)``:  return the code point at the given index of the CharSequence
 
 .. todo:: explain isWhitespace()
 


### PR DESCRIPTION
Correction: Java's Character class stores internally a single `char` value (16 bits), thus is not able to store an Unicode character. Check e.g this implementation: http://grepcode.com/file/repository.grepcode.com/java/root/jdk/openjdk/8u40-b25/java/lang/Character.java#Character.charValue%28%29